### PR TITLE
Change App model name column

### DIFF
--- a/aws_interface/dashboard/models.py
+++ b/aws_interface/dashboard/models.py
@@ -110,7 +110,7 @@ class User(AbstractUser):
 class App(models.Model):
     id = models.CharField(max_length=255, primary_key=True, default=shortuuid.uuid, editable=False)
     creation_date = models.DateTimeField(auto_now_add=True, editable=False, null=False, blank=False)
-    name = models.CharField(max_length=255, blank=False, unique=True)
+    name = models.CharField(max_length=255, blank=False, unique=False)
     user = models.ForeignKey(User, null=True, on_delete=models.CASCADE)
     vendor = models.CharField(max_length=255, default='aws')
 


### PR DESCRIPTION
Set name column of App model as non-unique.
(create_app in Util view prevents users from creating apps with the same name within their portfolio, but surely different users can create apps with the same name? If not so, this should be included in the logic as well on top of maintaining this column as unique). 
Found a bug while creating a new app called 'test' -> integrety error occured. 